### PR TITLE
Added machinery and instructions about adding new dependencies to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Then, the continuous integration server is available both at 3000 and 8080.
 ## Adding new dependencies
 
 Once docker compose is up and running, and you want to add some dependencies
-to `package.json` and updated `package-lock.json`, you have to do next in
+to [package.json](package.json) and updated [package-lock.json](package-lock.json), you have to do next in
 a separated terminal:
 
 ```bash
@@ -158,5 +158,29 @@ Have a look at the messages, because some mismatch between the dependencies
 of the new packages and the already recorded ones could break havoc.
 
 In those cases, you need to figure out the source of the problem, rollback
-both `package.json` and `package-lock.json`, and re-add the updated
+both [package.json](package.json) and [package-lock.json](package-lock.json), and re-add the updated
 dependency.
+
+## Running custom `npm run` commands
+
+Another usual issue is that the CI checks either on service or locally complain
+about styling. So, in order to run those checks locally you have to run:
+
+```bash
+NPM_RUN=lint docker compose -f docker-compose.devci.yml run npm_run
+```
+
+and to (blindly) apply the fixes:
+
+```bash
+docker compose -f docker-compose.devci.yml run npm_run
+```
+
+or
+
+```bash
+NPM_RUN=lintfix docker compose -f docker-compose.devci.yml run npm_run
+```
+
+Any other command defined in [package.json](package.json), like `test:unit`
+can also be used.

--- a/README.md
+++ b/README.md
@@ -137,3 +137,26 @@ docker compose -f docker-compose.devci.yml up
 ```
 
 Then, the continuous integration server is available both at 3000 and 8080.
+
+## Adding new dependencies
+
+Once docker compose is up and running, and you want to add some dependencies
+to `package.json` and updated `package-lock.json`, you have to do next in
+a separated terminal:
+
+```bash
+DEPENDENCIES=mynewdepency docker compose -f docker-compose.devci.yml run npm_install_deps
+```
+
+After that, you might need to restart it through
+
+```bash
+docker compose -f docker-compose.devci.yml restart nuxt
+```
+
+Have a look at the messages, because some mismatch between the dependencies
+of the new packages and the already recorded ones could break havoc.
+
+In those cases, you need to figure out the source of the problem, rollback
+both `package.json` and `package-lock.json`, and re-add the updated
+dependency.

--- a/docker-compose.devci.yml
+++ b/docker-compose.devci.yml
@@ -3,11 +3,69 @@ volumes:
   dist-volume:
   node-modules-volume:
 services:
+  npm_ci_deps:
+    build:
+      context: .
+      dockerfile: Dockerfile.devci
+    image: openebench-nuxt:devci
+    user: ${DEV_UID:-0}:${DEV_GID:-0}
+    command: npm ci
+    volumes:
+      - ./assets:/app/assets:ro
+      - ./components:/app/components:ro
+      - ./config:/app/config:ro
+      - ./layouts:/app/layouts:ro
+      - ./pages:/app/pages:ro
+      - ./plugins:/app/plugins:ro
+      - ./static:/app/static
+      - ./store:/app/store:ro
+      - ./stories:/app/stories:ro
+      - ./test:/app/test:ro
+      - ./jest.config.js:/app/jest.config.js:ro
+      - ./nuxt.config.js:/app/nuxt.config.js:ro
+      - ./package.json:/app/package.json:ro
+      - ./package-lock.json:/app/package-lock.json
+      - ./stylelint.config.js:/app/stylelint.config.js:ro
+      - ./tsconfig.json:/app/tsconfig.json:ro
+
+      - node-modules-volume:/app/node_modules
+  npm_install_deps:
+    build:
+      context: .
+      dockerfile: Dockerfile.devci
+    image: openebench-nuxt:devci
+    user: ${DEV_UID:-0}:${DEV_GID:-0}
+    profiles:
+      - manual
+    command: npm install ${DEPENDENCIES:-YOU_NEED_TO_PROVIDE_YOUR_DEPENDENCIES_THROUGH_DEPENDENCIES_VARIABLE_TO_DOCKER_COMPOSE}
+    volumes:
+      - ./assets:/app/assets:ro
+      - ./components:/app/components:ro
+      - ./config:/app/config:ro
+      - ./layouts:/app/layouts:ro
+      - ./pages:/app/pages:ro
+      - ./plugins:/app/plugins:ro
+      - ./static:/app/static
+      - ./store:/app/store:ro
+      - ./stories:/app/stories:ro
+      - ./test:/app/test:ro
+      - ./jest.config.js:/app/jest.config.js:ro
+      - ./nuxt.config.js:/app/nuxt.config.js:ro
+      - ./package.json:/app/package.json
+      - ./package-lock.json:/app/package-lock.json
+      - ./stylelint.config.js:/app/stylelint.config.js:ro
+      - ./tsconfig.json:/app/tsconfig.json:ro
+
+      - node-modules-volume:/app/node_modules
   nuxt:
     build:
       context: .
       dockerfile: Dockerfile.devci
     image: openebench-nuxt:devci
+    user: ${DEV_UID:-0}:${DEV_GID:-0}
+    depends_on:
+      npm_ci_deps:
+        condition: service_completed_successfully
     restart: on-failure
     volumes:
       - ./assets:/app/assets:ro

--- a/docker-compose.devci.yml
+++ b/docker-compose.devci.yml
@@ -57,6 +57,34 @@ services:
       - ./tsconfig.json:/app/tsconfig.json:ro
 
       - node-modules-volume:/app/node_modules
+  npm_run:
+    build:
+      context: .
+      dockerfile: Dockerfile.devci
+    image: openebench-nuxt:devci
+    user: ${DEV_UID:-0}:${DEV_GID:-0}
+    profiles:
+      - manual
+    command: npm run ${NPM_RUN:-lintfix}
+    volumes:
+      - ./assets:/app/assets
+      - ./components:/app/components
+      - ./config:/app/config
+      - ./layouts:/app/layouts
+      - ./pages:/app/pages
+      - ./plugins:/app/plugins
+      - ./static:/app/static
+      - ./store:/app/store
+      - ./stories:/app/stories
+      - ./test:/app/test
+      - ./jest.config.js:/app/jest.config.js:ro
+      - ./nuxt.config.js:/app/nuxt.config.js:ro
+      - ./package.json:/app/package.json
+      - ./package-lock.json:/app/package-lock.json
+      - ./stylelint.config.js:/app/stylelint.config.js:ro
+      - ./tsconfig.json:/app/tsconfig.json:ro
+
+      - node-modules-volume:/app/node_modules
   nuxt:
     build:
       context: .


### PR DESCRIPTION
As the development is performed using docker compose in order to assure same node version and same development environment, some usual operations, like adding a new dependency and properly update both `package.json` and `package-lock.json` got more complicated.

This pull request adds changes both to the docker compose used for local development and some instructions to end of `README.md` for developers.