### PR TITLE
feat: let user choose filename of PR

### DIFF
--- a/components/observatory/evaluation/Export/DialogPRfail.vue
+++ b/components/observatory/evaluation/Export/DialogPRfail.vue
@@ -1,11 +1,11 @@
 <template>
 	<v-dialog v-model="dialogPRfail" max-width="600">
-		<v-card class="pt-3 pb-3 pl-2 pr-2">
+		<v-card class="pa-0">
 			<v-card-title class="mt-0 pt-0 text-h6">
 				Making Pull Request
 			</v-card-title>
-			<v-row class="pb-5 pl-5 pr-5">
-				<v-alert class="text-caption pa-4 ml-3 mr-3" type="warning" outlined>
+			<v-row class="pb-5 pl-5 pr-5 mt-5" justify="center">
+				<v-alert class="text-caption pa-4 ml-3 mr-3" type="error" outlined>
 					<span class="text-overlay"><b>ERROR</b></span>
 					<br />
 					Something went wrong while making the pull request.

--- a/plugins/githubapp.js
+++ b/plugins/githubapp.js
@@ -10,6 +10,7 @@ export default function ({ $axios, $config: { GITHUBAPP_API_URL } }, inject) {
 
 	// Set baseURL to something different
 	githubapp.setBaseURL(GITHUBAPP_API_URL);
+	// githubapp.setBaseURL('http://localhost:3500');
 
 	// Inject to context as $api
 	inject('githubapp', githubapp);

--- a/store/observatory/evaluation/export.js
+++ b/store/observatory/evaluation/export.js
@@ -42,6 +42,7 @@ export const actions = {
 		const parameters = {
 			repo: payload.repo,
 			owner: payload.owner,
+			filename: payload.filename,
 			installationID: payload.installationID,
 			metadata: payload.metadata,
 		};


### PR DESCRIPTION
- Added a new field for filename in form:
![imagen](https://github.com/inab/openEBench-nuxt/assets/11412829/fc8ad5d3-7350-4353-b6f9-21954d4ff872)


- Passed the filename in the request.
- Fixed bug:  `repo` and `owner`, the ones in the text inputs, are used for both installation ID retrieval and making the pull request.