### PR TITLE
Fix some flicks on hover publications links

### DIFF
--- a/components/Cards/PosterList.vue
+++ b/components/Cards/PosterList.vue
@@ -95,18 +95,24 @@
 								<a
 									class="chip-icon"
 									target="_blank"
+                  title="Creative Commons Attribution 4.0 International License"
 									href="https://creativecommons.org/licenses/by/4.0/deed.en"
 								>
 									<img
 										src="@/static/posters/cc.png"
-										alt="CC"
+										alt="Creative Commons Attribution 4.0 International License"
+                    title="Creative Commons Attribution 4.0 International License"
 										class="logo chip-with-logo"
 									/>
 								</a>
-								<a target="_blank" :href="poster.link" class="chip-icon">
+								<a target="_blank"
+                  :href="poster.link"
+                  class="chip-icon"
+                  title="doi">
 									<img
 										src="@/static/posters/doi.svg"
-										alt="CC"
+										alt="doi"
+                    title="doi"
 										class="logo chip-with-logo"
 									/>
 								</a>
@@ -269,31 +275,32 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.logo {
-	width: 25px;
-	height: 25px;
-	border-radius: 50%;
-	opacity: 0.7;
-}
-
-.logo:hover {
-	width: 28px;
-	height: 28px;
-	box-shadow: 0 4px 20px rgba(0, 0, 0, 20%);
-	transition: box-shadow 0.3s ease-in-out;
-}
-
 .chip {
 	height: 35px;
 	text-align: center;
 	justify-content: center;
 	display: flex;
 	justify-content: center;
+  align-items: end;
 	gap: 10px;
-	a:hover {
-		display: block;
-		height: 28px;
-	}
+  flex: 1;
+  padding-bottom: 10px;
+	.chip-icon{
+    height: 23px;
+    transition: all .3s ease-in-out;
+    display: block;
+    &:hover {
+      transform: scale(1.4);
+    }
+    img {
+      height: 100%;
+      border-radius: 50%;
+      opacity: 0.7;
+    }
+    &:focus {
+      outline: none;
+    }
+  }
 }
 
 .poster-grid {
@@ -323,6 +330,7 @@ export default {
 	text-align: left;
 	word-break: break-word; /* Allow breaking long words */
 	overflow: hidden; /* Hide overflow text */
+  flex: 2;
 }
 
 .poster-title:hover {

--- a/components/Cards/PosterList.vue
+++ b/components/Cards/PosterList.vue
@@ -95,24 +95,26 @@
 								<a
 									class="chip-icon"
 									target="_blank"
-                  title="Creative Commons Attribution 4.0 International License"
+									title="Creative Commons Attribution 4.0 International License"
 									href="https://creativecommons.org/licenses/by/4.0/deed.en"
 								>
 									<img
 										src="@/static/posters/cc.png"
 										alt="Creative Commons Attribution 4.0 International License"
-                    title="Creative Commons Attribution 4.0 International License"
+										title="Creative Commons Attribution 4.0 International License"
 										class="logo chip-with-logo"
 									/>
 								</a>
-								<a target="_blank"
-                  :href="poster.link"
-                  class="chip-icon"
-                  title="doi">
+								<a
+									target="_blank"
+									:href="poster.link"
+									class="chip-icon"
+									title="doi"
+								>
 									<img
 										src="@/static/posters/doi.svg"
 										alt="doi"
-                    title="doi"
+										title="doi"
 										class="logo chip-with-logo"
 									/>
 								</a>
@@ -281,26 +283,26 @@ export default {
 	justify-content: center;
 	display: flex;
 	justify-content: center;
-  align-items: end;
+	align-items: end;
 	gap: 10px;
-  flex: 1;
-  padding-bottom: 10px;
-	.chip-icon{
-    height: 23px;
-    transition: all .3s ease-in-out;
-    display: block;
-    &:hover {
-      transform: scale(1.4);
-    }
-    img {
-      height: 100%;
-      border-radius: 50%;
-      opacity: 0.7;
-    }
-    &:focus {
-      outline: none;
-    }
-  }
+	flex: 1;
+	padding-bottom: 10px;
+	.chip-icon {
+		height: 23px;
+		transition: all 0.3s ease-in-out;
+		display: block;
+		&:hover {
+			transform: scale(1.4);
+		}
+		img {
+			height: 100%;
+			border-radius: 50%;
+			opacity: 0.7;
+		}
+		&:focus {
+			outline: none;
+		}
+	}
 }
 
 .poster-grid {
@@ -330,7 +332,7 @@ export default {
 	text-align: left;
 	word-break: break-word; /* Allow breaking long words */
 	overflow: hidden; /* Hide overflow text */
-  flex: 2;
+	flex: 2;
 }
 
 .poster-title:hover {

--- a/pages/publications.vue
+++ b/pages/publications.vue
@@ -32,7 +32,7 @@
 						</v-tab>
 
 						<v-tab-item class="ma-5 mt-5 mt-md-0" :transition="false">
-							<div class="transition-container" key="core">
+							<div key="core" class="transition-container">
 								<transition name="slide">
 									<div v-if="loading" class="loader-container">
 										<img :src="loaderGif" alt="Loading..." class="loader" />
@@ -46,7 +46,7 @@
 							</div>
 						</v-tab-item>
 						<v-tab-item class="ma-5 mt-5 mt-md-0">
-							<div class="transition-container" key="collaboration">
+							<div key="collaboration" class="transition-container">
 								<transition name="slide">
 									<div v-if="loading" class="loader-container">
 										<img :src="loaderGif" alt="Loading..." class="loader" />
@@ -80,7 +80,7 @@
 						<br />
 
 						<v-tab-item class="ma-5 mt-5 mt-md-0" :transition="false">
-							<div class="transition-container" key="OEB">
+							<div key="OEB" class="transition-container">
 								<transition name="slide">
 									<div v-if="loading" class="loader-container">
 										<img :src="loaderGif" alt="Loading..." class="loader" />
@@ -94,7 +94,7 @@
 							</div>
 						</v-tab-item>
 						<v-tab-item class="ma-5 mt-5 mt-md-0" :transition="false">
-							<div class="transition-container" key="MENTION">
+							<div key="MENTION" class="transition-container">
 								<transition name="slide">
 									<div v-if="loading" class="loader-container">
 										<img :src="loaderGif" alt="Loading..." class="loader" />
@@ -305,6 +305,6 @@ export default {
 }
 
 .tab-aligned {
-  justify-content: start;
+	justify-content: start;
 }
 </style>

--- a/pages/publications.vue
+++ b/pages/publications.vue
@@ -17,7 +17,7 @@
 
 		<v-tabs :vertical="vertical" class="mt-10">
 			<!-- Manuscripts -->
-			<v-tab>
+			<v-tab class="tab-aligned">
 				<v-icon left>mdi-text-box-multiple-outline</v-icon>
 				Manuscripts
 			</v-tab>
@@ -64,7 +64,7 @@
 			</v-tab-item>
 
 			<!-- Posters -->
-			<v-tab>
+			<v-tab class="tab-aligned">
 				<v-icon left>mdi-file-table-outline</v-icon>
 				Posters
 			</v-tab>
@@ -302,5 +302,9 @@ export default {
 .manuscripts-container,
 .posters-container {
 	width: 100%; /* Ensure full width */
+}
+
+.tab-aligned {
+  justify-content: start;
 }
 </style>


### PR DESCRIPTION
We have detected that in the "/publications" view there little annoying flick when hovering over the new links. We solved this and align tabs text in that view. Also we add tooltip in links to help in UX side.